### PR TITLE
Change the type of the syntaxIdentifier to an enum

### DIFF
--- a/Sources/Highlight/JsonSyntaxHighlightProvider.swift
+++ b/Sources/Highlight/JsonSyntaxHighlightProvider.swift
@@ -13,10 +13,10 @@ open class JsonSyntaxHighlightProvider: SyntaxHighlightProvider {
     ///
     /// - parameters:
     ///   - attributedText:      The `NSMutableAttributedString` that should be highlighted.
-    ///   - syntaxIdentifier:        The identifier of the syntax that should be used to highlight the given `String`
-    open func highlight(_ attributedText: NSMutableAttributedString, as syntaxIdentifier: String) {
-        if syntaxIdentifier.lowercased() != "json" {
-            debugPrint("Highlighting '\(syntaxIdentifier)' is not supported. Supported ones are: 'json'")
+    ///   - syntaxIdentifier:        The syntax that should be used to highlight the given `String`
+    open func highlight(_ attributedText: NSMutableAttributedString, as syntax: Syntax) {
+        guard case .json = syntax else {
+            debugPrint("Highlighting '\(syntax)' is not supported. Supported ones are: 'json'")
             return
         }
         

--- a/Sources/Highlight/Syntax.swift
+++ b/Sources/Highlight/Syntax.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum Syntax {
+    case json
+    case other(identifier: String)
+}

--- a/Sources/Highlight/SyntaxHightlightProvider.swift
+++ b/Sources/Highlight/SyntaxHightlightProvider.swift
@@ -7,21 +7,21 @@ public protocol SyntaxHighlightProvider {
     ///
     /// - parameters:
     ///   - text:      The `String` that should be highlighted.
-    ///   - syntaxIdentifier:        The identifier of the syntax that should be used to highlight the given `String`
-    func highlight(_ text: String, as syntaxIdentifier: String) -> NSAttributedString
+    ///   - syntaxIdentifier:        The syntax that should be used to highlight the given `String`
+    func highlight(_ text: String, as syntax: Syntax) -> NSAttributedString
     
     /// Modify the given `NSMutableAttributedString` to be highlighted according to the syntax.
     ///
     /// - parameters:
     ///   - attributedText:      The `NSMutableAttributedString` that should be highlighted.
-    ///   - syntaxIdentifier:        The identifier of the syntax that should be used to highlight the given `String`
-    func highlight(_ attributedText: NSMutableAttributedString, as syntaxIdentifier: String)
+    ///   - syntaxIdentifier:        The syntax that should be used to highlight the given `String`
+    func highlight(_ attributedText: NSMutableAttributedString, as syntax: Syntax)
 }
 
 public extension SyntaxHighlightProvider {
-    func highlight(_ text: String, as syntaxIdentifier: String) -> NSAttributedString {
+    func highlight(_ text: String, as syntax: Syntax) -> NSAttributedString {
         let result = NSMutableAttributedString(string: text)
-        highlight(result, as: syntaxIdentifier)
+        highlight(result, as: syntax)
         return result
     }
 }


### PR DESCRIPTION
## Summary
This PR creates a `Syntax` enum with predefined cases for currently supported ones and one additional `other(String)` case for describing external syntaxes.

## Motivation and Context
This ensures better code style and compiler checking than matching strings.

## Details
- Create `Syntax` enum
- Modify `SyntaxHighlightProvider` API to use the `Syntax` type
- Modify the guard clause in `JsonSyntaxHighlightProvider` accordingly

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have written/altered unit tests for the changes.
- [x] Only necessary files have been added/altered.
