### PR TITLE
Add unknown color and font and options to set the fontsize

### DIFF
--- a/Sources/Highlight/DefaultJsonSyntaxHighlightingTheme.swift
+++ b/Sources/Highlight/DefaultJsonSyntaxHighlightingTheme.swift
@@ -1,22 +1,38 @@
+import Foundation
+import CoreGraphics
+
 public struct DefaultJsonSyntaxHighlightingTheme: JsonSyntaxHighlightingTheme {
+    
+    public init(fontSize size: CGFloat = 13) {
+        whitespaceFont = .monospacedSystemFont(ofSize: size, weight: .medium)
+        operatorFont = .monospacedSystemFont(ofSize: size, weight: .medium)
+        numericValueFont = .monospacedSystemFont(ofSize: size, weight: .medium)
+        stringValueFont = .monospacedSystemFont(ofSize: size, weight: .medium)
+        literalFont = .monospacedSystemFont(ofSize: size, weight: .bold)
+        unknownFont = .monospacedSystemFont(ofSize: size, weight: .medium)
+    }
     
     public var whitespaceColor: Color = .jsonOperatorColor
     
-    public var whitespaceFont: Font = .monospacedSystemFont(ofSize: 13, weight: .medium)
+    public var whitespaceFont: Font
     
     public var operatorColor: Color = .jsonOperatorColor
     
-    public var operatorFont: Font = .monospacedSystemFont(ofSize: 13, weight: .medium)
+    public var operatorFont: Font
     
     public var numericValueColor: Color = .jsonNumberColor
     
-    public var numericValueFont: Font = .monospacedSystemFont(ofSize: 13, weight: .medium)
+    public var numericValueFont: Font
     
     public var stringValueColor: Color = .jsonStringColor
     
-    public var stringValueFont: Font = .monospacedSystemFont(ofSize: 13, weight: .medium)
+    public var stringValueFont: Font
     
     public var literalColor: Color = .jsonLiteralColor
     
-    public var literalFont: Font = .monospacedSystemFont(ofSize: 13, weight: .bold)
+    public var literalFont: Font
+    
+    public var unknownColor: Color = .jsonOperatorColor
+    
+    public var unknownFont: Font
 }

--- a/Sources/Highlight/JsonSyntaxHighlightProvider.swift
+++ b/Sources/Highlight/JsonSyntaxHighlightProvider.swift
@@ -25,6 +25,8 @@ open class JsonSyntaxHighlightProvider: SyntaxHighlightProvider {
             return
         }
         
+        attributedText.addAttributes([ .foregroundColor : theme.unknownColor, .font : theme.unknownFont ], range: NSRange(location: 0, length: attributedText.length))
+        
         let theme = self.theme
 
         let tokenizer = JsonTokenizer()
@@ -41,8 +43,8 @@ open class JsonSyntaxHighlightProvider: SyntaxHighlightProvider {
                 attributedText.setAttributes([ .foregroundColor : theme.numericValueColor, .font : theme.numericValueFont ], range: range)
             case .literal(let range):
                 attributedText.setAttributes([ .foregroundColor : theme.literalColor, .font : theme.literalFont ], range: range)
-            case .unknown(let range, _):
-                attributedText.setAttributes([ .foregroundColor : theme.unknownColor, .font : theme.unknownFont ], range: range)
+            case .unknown(_, _):
+                return
             }
 
         }

--- a/Sources/Highlight/JsonSyntaxHighlightProvider.swift
+++ b/Sources/Highlight/JsonSyntaxHighlightProvider.swift
@@ -6,8 +6,13 @@ open class JsonSyntaxHighlightProvider: SyntaxHighlightProvider {
     /// A static instance of this provider
     public static let shared: JsonSyntaxHighlightProvider = JsonSyntaxHighlightProvider()
     
+    /// Initialize an instance of the `JsonSyntaxHighlightProvider` class  with a theme
+    public init(theme: JsonSyntaxHighlightingTheme? = nil) {
+        self.theme = theme ?? DefaultJsonSyntaxHighlightingTheme()
+    }
+    
     /// The theme which will be used to highlight the JSON data
-    open var theme: JsonSyntaxHighlightingTheme = DefaultJsonSyntaxHighlightingTheme()
+    open var theme: JsonSyntaxHighlightingTheme
     
     /// Modify the given `NSMutableAttributedString` to be highlighted according to the syntax.
     ///
@@ -36,9 +41,8 @@ open class JsonSyntaxHighlightProvider: SyntaxHighlightProvider {
                 attributedText.setAttributes([ .foregroundColor : theme.numericValueColor, .font : theme.numericValueFont ], range: range)
             case .literal(let range):
                 attributedText.setAttributes([ .foregroundColor : theme.literalColor, .font : theme.literalFont ], range: range)
-            case .unknown(_, let error):
-                debugPrint("Error parsing the syntax: \(error.localizedDescription)")
-                return
+            case .unknown(let range, _):
+                attributedText.setAttributes([ .foregroundColor : theme.unknownColor, .font : theme.unknownFont ], range: range)
             }
 
         }

--- a/Sources/Highlight/JsonSyntaxHighlightingTheme.swift
+++ b/Sources/Highlight/JsonSyntaxHighlightingTheme.swift
@@ -40,4 +40,10 @@ public protocol JsonSyntaxHighlightingTheme {
     
     /// The font for literals like 'true', 'false' or 'null'
     var literalFont: Font { get }
+    
+    /// The color for text which could not be parsed correctly
+    var unknownColor: Color { get }
+    
+    /// The font for text which could not be parsed correctly
+    var unknownFont: Font { get }
 }


### PR DESCRIPTION
## Summary
This PR adds a color and font for unknown tokens.

## Motivation and Context
This allows for better customization of the color and font of unparsable text.

## Details
- Add `unknownColor` and `unknownFont` properties to the `JsonSyntaxHighlightingTheme` protocol and `DefaultJsonSyntaxHighlightingTheme` struct
- Add initializer to `DefaultJsonSyntaxHighlightingTheme` to customize the fontSize
- Add initializer to `JsonSyntaxHighlightProvider` to set the theme when initializing
- Remove `debugPrint()` when an error occurs, when syntax highlighting in editable text fields this would completely spam the console


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have written/altered unit tests for the changes.
- [x] Only necessary files have been added/altered.
